### PR TITLE
remove appi prefix from server component

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -74,21 +74,24 @@ WSGI_APPLICATION = 'app.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        # 'ENGINE': 'django.db.backends.sqlite3',
-        # 'NAME': BASE_DIR / 'db.sqlite3',
-
-        # Production database settings:
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('DB_NAME', default=''),
-        'USER': os.getenv('DB_USER', default=''),
-        'PASSWORD': os.getenv('DB_PASSWORD', default=''),
-        'HOST': os.getenv('DB_HOST', default=''),
-        'PORT': os.getenv('DB_PORT', default=''),
+if DEBUG:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.getenv('DB_NAME', default=''),
+            'USER': os.getenv('DB_USER', default=''),
+            'PASSWORD': os.getenv('DB_PASSWORD', default=''),
+            'HOST': os.getenv('DB_HOST', default=''),
+            'PORT': os.getenv('DB_PORT', default=''),
+        }
+    }
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators

--- a/app/urls.py
+++ b/app/urls.py
@@ -34,15 +34,11 @@ schema_view = get_schema_view(
     public=True,
 )
 
-api_urlpatterns = [
+urlpatterns = [
     path('admin/', admin.site.urls),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),  # Swagger UI
     path('account/', include('account.urls')),
     path('advertisement/', include("advertisement.urls"))
-]
-
-urlpatterns = [
-    path('api/', include(api_urlpatterns)),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
NOTE: On VPS, we have NGINX configured such that if the request path starts with /api, it forwards the request to the backend, removing the /api prefix before passing it. This means the backend server is unaware of the /api prefix. For frontend requests, /api must be included in the path to correctly route requests through NGINX.